### PR TITLE
Correct wintype detection

### DIFF
--- a/src/sysdep.cc
+++ b/src/sysdep.cc
@@ -117,7 +117,7 @@ Sysdep::init_wintype ()
               windows_short_name = "w2k";
             }
         }
-      if (Win6p ())
+      else if (Win6p ())
         {
           wintype = WINTYPE_WINDOWS_NT6;
           // 設定ファイルのパス (user-config-path) が変わるため wxp のままとする

--- a/unittest/lisp-tests.l
+++ b/unittest/lisp-tests.l
@@ -19,6 +19,38 @@
 
 (let ((os-version (list (os-major-version) (os-minor-version)))
       (os-features '(:windows-8 :windows-7 :windows-vista :windows-xp :windows-2000)))
+  ;; Windows 2000
+  (when (equalp '(5 0) os-version)
+    (deftest os-features-2000-test ()
+      "*features* contains :windows-2000, :windows-nt"
+      (mapcar #'(lambda (k) (not (null (featurep k)))) os-features)
+      => (nil nil nil nil t))
+    (deftest os-platform-2000-test ()
+      "(os-platform) should return :windows-2000"
+      (os-platform)
+      => windows-2000)
+    (deftest user-config-path-and-dump-image-path-2000-test ()
+      "(user-config-path) and (si:dump-image-path) should return w2k"
+      (values (pathname-name (user-config-path))
+              (pathname-type (si:dump-image-path)))
+      => "w2k"
+      => "w2k"))
+  ;; Windows XP
+  (when (equalp '(5 1) os-version)
+    (deftest os-features-xp-test ()
+      "*features* contains :windows-xp, :windows-2000, :windows-nt"
+      (mapcar #'(lambda (k) (not (null (featurep k)))) os-features)
+      => (nil nil nil t t))
+    (deftest os-platform-xp-test ()
+      "(os-platform) should return :windows-xp"
+      (os-platform)
+      => windows-xp)
+    (deftest user-config-path-and-dump-image-path-xp-test ()
+      "(user-config-path) and (si:dump-image-path) should return wxp"
+      (values (pathname-name (user-config-path))
+              (pathname-type (si:dump-image-path)))
+      => "wxp"
+      => "wxp"))
   ;; Windows Vista
   (when (equalp '(6 0) os-version)
     (deftest os-features-vista-test ()


### PR DESCRIPTION
Windows XP上で実行したときのダンプファイルが"*.wnt"になってしまう（未確認ですが、Windows 2000でもおそらく同様になる）問題を直しました。
