### PR TITLE
fix typo in reference

### DIFF
--- a/reference/reference.xml
+++ b/reference/reference.xml
@@ -2207,7 +2207,7 @@ xyzzy終了時に実行されます。このフック変数の実行がnilだと
 <package>lisp</package>
 <description>
 読み取り時評価(read-time evaluation)を制御します。
-*read-eval*がnon-nilなら #. リーダマクロは通常どうりに動作します。
+*read-eval*がnon-nilなら #. リーダマクロは通常どおりに動作します。
 nilならreader-errorが発生します。
 
 標準はtです。


### PR DESCRIPTION
リファレンスの `*read-eval*` の項の typo の修正です。

ただ、リファレンスにリーダマクロ自体の説明が無いので、
もう少し解説が欲しい気もします。
自分なら
「_read-eval_がnon-nilなら #. リーダマクロは通常どおり直後のS式を評価した結果を値とします。」
といった感じでしょうか。
