### PR TITLE
エディタからのevalの際のカレントパッケージを*package*そのものではなく*buffer-package*をベースにした。

### DIFF
--- a/lisp/cmds.l
+++ b/lisp/cmds.l
@@ -27,7 +27,7 @@
 	  fast-scroll-up fast-scroll-down scroll-up-both-window
 	  scroll-down-both-window scroll-other-window scroll-up-other-window
 	  scroll-down-other-window scroll-left scroll-right
-	  eval-expression set-variable
+	  eval-expression set-buffer-package set-variable
 	  digit-argument negative-argument universal-argument
 	  quote-char undefined what-cursor-position *executing-macro*
 	  repeat-complex-command overwrite-char
@@ -651,6 +651,17 @@
 (defun eval-expression (x)
   (interactive "xEval: ")
   (message "~S" (eval x)))
+
+(defun set-buffer-package (package-name)
+  (interactive
+      (list (completing-read
+	     "Package:" #1=(mapcar #'package-name (list-all-packages))
+	     :case-fold t
+	     :default (or *buffer-package* "user")
+	     :must-match t)))
+  (setf *buffer-package*
+	(find package-name #1#
+	      :test #'string-equal)))
 
 (defun set-variable (var)
   (interactive "vSet variable: ")

--- a/lisp/lispmode.l
+++ b/lisp/lispmode.l
@@ -7,7 +7,8 @@
 
 (in-package "editor")
 
-(export '(*lisp-mode-hook* *lisp-interaction-mode-hook* *lisp-indent-offset* 
+(export '(*lisp-mode-hook* *lisp-interaction-mode-hook* *lisp-indent-offset*
+	  *find-buffer-package-hook*
 	  *lisp-body-indention* *lisp-body-indent* lisp-complete-symbol
 	  lisp-indent-hook lisp-paren-imaginary-offset
 	  lisp-indent-line lisp-newline-and-indent
@@ -21,6 +22,7 @@
 (defvar *lisp-mode-hook* nil)
 (defvar *lisp-popup-completion-list* nil)
 (defvar *lisp-interaction-mode-hook* nil)
+(defvar *find-buffer-package-hook* '())
 (defvar *lisp-indent-offset* nil)
 (defvar *lisp-body-indention* 2)
 (defvar *lisp-body-indent* 2)
@@ -190,6 +192,23 @@
 		  (and ep (< ep p) (decf p 2))
 		  p))))))))
 
+(defun lisp-search-in-package ()
+  (ignore-errors
+    (save-excursion
+      (or (scan-buffer "(\\(lisp:|lisp::\\)?in-package\\([^)]+\\))" :reverse t :regexp t)
+	  (scan-buffer "(\\(lisp:|lisp::\\)?in-package\\([^)]+\\))" :reverse nil :regexp t))
+      (let (*read-eval*)
+	(find-package (read-from-string (match-string 2)))))))
+
+(defun find-buffer-package ()
+  (or (and (stringp *buffer-package*)
+	   (find-package *buffer-package*))
+      (dolist (func *find-buffer-package-hook*)
+	(let ((ret (funcall func)))
+	  (when ret
+	    (return ret))))
+      *package*))
+
 (defun calc-lisp-indent (opoint)
   (protect-match-data
     (let ((begin-paren (and lisp-indent-close-paren
@@ -208,9 +227,7 @@
 		      (looking-back "'")))
 	     (+ (current-column) 1))
 	    (t
-	     (let ((package (or (and (stringp *buffer-package*)
-				     (find-package *buffer-package*))
-				*package*)))
+	     (let ((package (find-buffer-package)))
 	       (when (save-excursion
 		       (when (and (up-list -1 t)
 				  (looking-for "((")
@@ -337,7 +354,7 @@
       (rotatef from to))
     (let ((s (make-buffer-stream (selected-buffer) from to)))
       (handler-case
-	  (let ((*package* *package*))
+	  (let ((*package* (find-buffer-package)))
 	    (while (< (buffer-stream-point s) to)
 	      (let ((form (read s nil '#1=#:eof)))
 		(when (eq form '#1#)
@@ -562,6 +579,8 @@
     (setq need-not-save t)
     (make-local-variable 'auto-save)
     (setq auto-save nil))
+  (make-local-variable '*find-buffer-package-hook*)
+  (add-hook '*find-buffer-package-hook* 'lisp-search-in-package)
   (run-hooks '*lisp-interaction-mode-hook*))
 
 (defvar *kill-buffer-kills-scratch* nil)

--- a/reference/reference.xml
+++ b/reference/reference.xml
@@ -1241,6 +1241,29 @@ non-nil のとき、ファイラでファイルタイプに応じたアイコン
 </chapter>
 
 <chapter>
+<title>*find-buffer-package-hook*</title>
+<type>Variable</type>
+<arguments></arguments>
+<package>editor</package>
+<description>
+eval-region時のパッケージを決定する際に利用します。
+
+eval-region時パッケージの決定は以下の順序になります。
+1.*buffer-package*に代入された値
+2.*find-buffer-package-hook*の評価結果
+
+補足：
+  xyzzy 0.2.2.239? から利用可能です。
+</description>
+<seealso>eval-region</seealso>
+<seealso>*buffer-package*</seealso>
+<seealso>set-buffer-package</seealso>
+<link></link>
+<section>変数と定数</section>
+<file>lispmode.l</file>
+</chapter>
+
+<chapter>
 <title>*find-file-file-not-found-hook*</title>
 <type>Variable</type>
 <arguments></arguments>
@@ -24258,6 +24281,24 @@ buffer-fileio-encodingで参照することができます。
 <seealso>not-modified</seealso>
 <section>バッファ</section>
 <file>builtin.l</file>
+</chapter>
+
+<chapter>
+<title>set-buffer-package</title>
+<type>Function</type>
+<arguments>set-buffer-package PACKAGE-NAME</arguments>
+<package>editor</package>
+<description>
+*buffer-package*を設定するコマンドです。
+
+補足：
+  xyzzy 0.2.2.239? から利用可能です。
+</description>
+<seealso>eval-region</seealso>
+<seealso>*buffer-package*</seealso>
+<link></link>
+<section>バッファ</section>
+<file>cmds.l</file>
 </chapter>
 
 <chapter>


### PR DESCRIPTION
付随してset-packageコマンドの定義

_lisp-interaction-mode-package_を用意するよりは影響範囲がでかい事が多少懸念です。
eval-expressionはuserパッケージに固定した方が「エディタ」として利用する人には便利かもしれません…
