### PR TITLE
reduce の from-end パラメータに t を指定した時の不具合を修正. #322

### DIFF
--- a/lisp/sequence.l
+++ b/lisp/sequence.l
@@ -160,7 +160,7 @@
 	     (decf end)
 	     (setq initial-value (funcall key (elt sequence end))))
 	   (do ((x initial-value (funcall function
-					  (funcall key (elt sequence (decf end)) x))))
+					  (funcall key (elt sequence (decf end))) x)))
 	       ((= start end) x))))))
 
 (defun remove-duplicates (sequence &key from-end test test-not (start 0) end (key #'identity))

--- a/unittest/sequence-tests.l
+++ b/unittest/sequence-tests.l
@@ -151,7 +151,9 @@
   (values
    (reduce #'+ '((1) (1 2) (1 2 3)) :key #'length)
    (reduce #'* #(0 1 2 3 4 0) :key #'1+ :start 1 :end 5)
-   (reduce #'+ "123456789" :key #'digit-char-p))
+   (reduce #'+ "123456789" :key #'digit-char-p)
+   (reduce #'- '(1 2 3 4) :key #'1- :from-end t))
   => 6
   => 120
-  => 45)
+  => 45
+  => -2)


### PR DESCRIPTION
from-endパラメータ に t を指定した時に、第1引数とkeyの関数に渡る値がおかくなっていたので修正しました。
