### PR TITLE
ole-methodでNull値を渡せるようにする

### DIFF
--- a/src/gen-syms.cc
+++ b/src/gen-syms.cc
@@ -1238,6 +1238,7 @@ static symbols kwd[] =
   DEFKWD2 (hiragana),
   DEFKWD2 (katakana),
   DEFKWD2 (password-char),
+  DEFKWD2 (null),
   DEFKWD2 (non-null),
   DEFKWD2 (must-match),
   DEFKWD2 (enable),

--- a/src/oledata.cc
+++ b/src/oledata.cc
@@ -256,6 +256,11 @@ obj2variant (lisp object, VARIANT &variant)
               V_VT (&variant) = VT_EMPTY;
               return;
             }
+          if (object == Knull)
+            {
+              V_VT (&variant) = VT_NULL;
+              return;
+            }
           break;
 
         case Tlong_int:

--- a/unittest/ole-tests.l
+++ b/unittest/ole-tests.l
@@ -1,0 +1,12 @@
+(deftest ole-method-null-and-empty ()
+  "ole-method‚ÅNull’l‚ÆEmpty’l‚ğ“n‚·"
+  (unwind-protect
+      (let ((sc (ole-create-object "ScriptControl")))
+        (ole-putprop sc 'Language "JScript")
+        (ole-method sc 'AddCode "function f (a) { return '' + a; }")
+        (values
+         (ole-method sc 'Run "f" :null)
+         (ole-method sc 'Run "f" :empty)))
+    (gc))
+  => "null"
+  => "undefined")


### PR DESCRIPTION
#361 に関連して。

http://twitter.com/cubeon/status/258834512237187072

> # xyzzy のoleを使ってのexcel制御で
> 
> WorkSheets("Sheet1").Copy After:=WorkSheets("sheet4")
> みたいにAfterに値渡す方法はないんですよねぇ…

上記の場合は名前付き引数がなくても引数省略かNull値を渡す方法があれば
対応可能だったのですが、どちらもできないようなのでNull値を渡す方法を
設けてみました。
キーワードシンボル :null をNull値として渡すようにしてあります。
