### PR TITLE
HTML5 キーワードから空要素の終了タグを削除

### DIFF
--- a/etc/HTML5
+++ b/etc/HTML5
@@ -6,7 +6,6 @@
 <address
 </address
 <area
-</area
 <article
 </article
 <aside
@@ -16,7 +15,6 @@
 <b
 </b
 <base
-</base
 <bdi
 </bdi
 <bdo
@@ -26,7 +24,6 @@
 <body
 </body
 <br
-</br
 <button
 </button
 <canvas
@@ -38,7 +35,6 @@
 <code
 </code
 <col
-</col
 <colgroup
 </colgroup
 <command
@@ -64,7 +60,6 @@
 <em
 </em
 <embed
-</embed
 <fieldset
 </fieldset
 <figcaption
@@ -94,7 +89,6 @@
 <hgroup
 </hgroup
 <hr
-</hr
 <html
 </html
 <i
@@ -102,15 +96,12 @@
 <iframe
 </iframe
 <img
-</img
 <input
-</input
 <ins
 </ins
 <kbd
 </kbd
 <keygen
-</keygen
 <label
 </label
 <legend
@@ -118,7 +109,6 @@
 <li
 </li
 <link
-</link
 <map
 </map
 <mark
@@ -128,7 +118,6 @@
 <menu
 </menu
 <meta
-</meta
 <meter
 </meter
 <nav
@@ -148,7 +137,6 @@
 <p
 </p
 <param
-</param
 <pre
 </pre
 <progress
@@ -218,7 +206,6 @@
 <video
 </video
 <wbr
-</wbr
 
 ;*1
 accept


### PR DESCRIPTION
HTML5 仕様で No end tag となっている要素の終了タグを削除しました。
